### PR TITLE
[5.x] Disable network probes API

### DIFF
--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -9,7 +9,6 @@
   - [Presence Channel Storage](#presence-channel-storage)
   - [Debugging](#debugging)
   - [Statsitics](#statsitics)
-  - [Probes API](#probes-api)
 - [Databases](#databases)
   - [Redis](#redis)
   - [Prometheus](#prometheus)
@@ -138,20 +137,6 @@ For distributed systems:
 - `prometheus` - Stats are read from a Prometheus server REST API (`PROMETHEUS_ENABLED` should be `true` and you should have the Prometheus server scrape metrics from the `/metrics` endpoint); [see Prometheus configuration](#prometheus))
 
 **The scraping service is not provided and you should set up the Prometheus server to scrape `/metrics` in order to be able to read them.**
-
-## Probes API
-
-Probes API allows you to change the network state for probing on `/health` and `/ready` endpoint from external sources. For example, you can toggle on or off the rejection for new connections:
-
-| Environment variable | Object dot-path | Default | Available values | Description |
-| - | - | - | - | - |
-| `NETWORK_PROBES_API_ENABLED` | `network.probesApi.enabled` | `false` | `true`, `false` | Wether to enable the network probes API. |
-| `NETWORK_PROBES_API_TOKEN` | `network.probesApi.token` | `probe-token` | - | The API token for network probes API authentication. |
-
-To call the probes API on rejecting connections, call the following endpoints:
-
-- `POST` `/probes/reject-new-connections?token=[your_token]` - make the server reject new connections
-- `POST` `/probes/accept-new-connections?token=[your_token]` - make the server accept new connections
 
 # Databases
 

--- a/src/api/http-api.ts
+++ b/src/api/http-api.ts
@@ -58,11 +58,6 @@ export class HttpApi {
         if (this.options.prometheus.enabled) {
             this.express.get('/metrics', (req, res) => this.getPrometheusMetrics(req, res));
         }
-
-        if (this.options.network.probesApi.enabled) {
-            this.express.post('/probes/reject-new-connections', (req, res) => this.rejectNewConnections(req, res));
-            this.express.post('/probes/accept-new-connections', (req, res) => this.acceptNewConnections(req, res));
-        }
     }
 
     /**
@@ -317,54 +312,6 @@ export class HttpApi {
     }
 
     /**
-     * Reject new connections from external clients.
-     *
-     * @param  {any}  req
-     * @param  {any}  res
-     * @return {boolean}
-     */
-    protected rejectNewConnections(req, res): boolean {
-        this.probesApiTokenIsValid(req.query.token).then(isValid => {
-            if (isValid) {
-                if (this.server.closing) {
-                    return res.json({ acknowledged: true });
-                }
-
-                this.server.rejectNewConnections = true;
-                res.json({ acknowledged: true });
-            } else {
-                this.unauthorizedResponse(req, res);
-            }
-        });
-
-        return true;
-    }
-
-    /**
-     * Accept new connections from external clients.
-     *
-     * @param  {any}  req
-     * @param  {any}  res
-     * @return {boolean}
-     */
-    protected acceptNewConnections(req, res): boolean {
-        this.probesApiTokenIsValid(req.query.token).then(isValid => {
-            if (isValid) {
-                if (this.server.closing) {
-                    return res.json({ acknowledged: true });
-                }
-
-                this.server.rejectNewConnections = false;
-                res.json({ acknowledged: true });
-            } else {
-                this.unauthorizedResponse(req, res);
-            }
-        });
-
-        return true;
-    }
-
-    /**
      * Find a Socket by Id in a given namespace.
      *
      * @param  {string}  namespace
@@ -522,16 +469,6 @@ export class HttpApi {
                 }
             });
         });
-    }
-
-    /**
-     * Check if the given Probes API token is valid.
-     *
-     * @param  {string}  token
-     * @return {Promise<boolean>}
-     */
-    protected probesApiTokenIsValid(token: string): Promise<boolean> {
-        return new Promise(resolve => resolve(this.options.network.probesApi.token === token));
     }
 
     /**

--- a/src/echo-server.ts
+++ b/src/echo-server.ts
@@ -88,12 +88,6 @@ export class EchoServer {
             process_id: process.pid || uuidv4(),
             pod_id: null,
         },
-        network: {
-            probesApi: {
-                enabled: false,
-                token: 'probe-token',
-            },
-        },
         port: 6001,
         presence: {
             storage: {


### PR DESCRIPTION
Network probes API are no longer needed since the [network watcher](https://github.com/soketi/network-watcher) can be configured to watch after pods that have the annotation set to `yes`
